### PR TITLE
Update build.gradle

### DIFF
--- a/materialviewpager/build.gradle
+++ b/materialviewpager/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     compile 'com.nineoldandroids:library:2.4.0'
 
-    compile 'com.flaviofaria:kenburnsview:1.0.6'
+    compile 'com.flaviofaria:kenburnsview:1.0.7'
     compile 'com.jpardogo.materialtabstrip:library:1.1.0'
     compile 'com.github.ksoichiro:android-observablescrollview:1.5.2'
     compile 'com.squareup.picasso:picasso:2.5.2'


### PR DESCRIPTION
Update to the latest KenBurnsView v.1.0.7

Drawable rect is only updated if it has meaningful dimensions.
Fixes drawable scaling under certain circumstances.
Fixes outdated drawable bounds in RandomTransitionGenerator.